### PR TITLE
Add requirement about Google tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Requirements
 * Android Studio 0.2.x
 * Android 4.3 SDK
 * Android Support Library, revision 18 or newer
+* Google Repository & Google Play service tool, version 32 or new.
 * android-websockets library: https://github.com/irccloud/android-websockets
 * An Android device running Android 2.2 or newer
 


### PR DESCRIPTION
I got some issues on gradle when loading android project.
```
Could not find com.google.android.gms:play-services-base:9.4.0
```
It was because my google play store / google repository library version was not the newest one. It has been cleared after update.
How about add this as a comment on a requirement? Please look on.