### PR TITLE
fixed database cursor leaks in IRCCloudApplicationBase

### DIFF
--- a/src/com/irccloud/android/IRCCloudApplicationBase.java
+++ b/src/com/irccloud/android/IRCCloudApplicationBase.java
@@ -105,6 +105,8 @@ public class IRCCloudApplicationBase extends Application {
                         editor.remove("notify_ringtone");
                         editor.commit();
                     }
+                }
+                if (c != null && !c.isClosed()) {
                     c.close();
                 }
             }
@@ -142,6 +144,8 @@ public class IRCCloudApplicationBase extends Application {
                         editor.remove("notify_ringtone");
                         editor.commit();
                     }
+                }
+                if (c != null && !c.isClosed()) {
                     c.close();
                 }
             }


### PR DESCRIPTION
Dear developers,

To fix issue #147, I moved the cursor closing code in the onCreate() method outside the if block to make sure the cursor is always closed even when it is empty (when c.moveToFirst() returns false).

@c99koder please let me know if there are any problems. Thanks.