### PR TITLE
indicate that forgot-password doesn't reset

### DIFF
--- a/res/layout/activity_login.xml
+++ b/res/layout/activity_login.xml
@@ -201,7 +201,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Forgotten your password?"
+                    android:text="Password too long, hard to type or forgotten?"
                     android:textColor="#0b2e60"
                     android:textSize="14sp" />
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -46,7 +46,7 @@
     <string name="title_activity_imgur_auth">Login to Imgur</string>
     <string name="action_settings">Settings</string>
     <string name="TOS">By signing up, you agree to our <a href="https://www.irccloud.com/terms">Terms\u00A0of\u00A0Service</a></string>
-    <string name="forgotPassword">Forgotten your password? <a href="#">Get\u00A0an\u00A0access\u00A0link</a></string>
+    <string name="forgotPassword">Password too long, hard to type or forgotten? <a href="#">Get\u00A0an\u00A0access\u00A0link</a></string>
     <string name="enterpriseLearnMore">Looking for the Standard Edition? <a href="#">Get\u00A0it\u00A0here</a></string>
     <string name="title_activity_uploads">File Uploads</string>
     <string name="title_activity_pastebin">Pastebin</string>


### PR DESCRIPTION
my password is a randomly generated key in my password manager,
so I prefer to login via the 'forgot pasword' tool. However
I've not really 'Forgotten' my password, and I don't want to
reset it. It took me a while to realise I could still use this
feature as a magic-login-link when starting out.